### PR TITLE
Switch to query bindings from explicit template strings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,15 +2,18 @@
 import { Results } from 'realm';
 export declare type ILogicOperator = 'AND' | 'OR';
 export declare type EqualValueType = string | number | boolean | Date;
-export declare type CompareValueType = number | Date;
+export declare type CompareValueType = number | Date
+export declare type CriteriaFunc = { (pladholders: string[]): string };
+export declare type CriteriaHof = { (): string };
 declare class RealmQuery {
     private objects;
-    private criteria;
+    protected criteria: any[];
+    protected values: any[]; // Values to be bound to query. Deferred appending till binding done in toString()
     private inGroup;
     private sortField;
     private sortReverse;
     constructor(objects?: Results<any>);
-    addCriteria(critera: any): RealmQuery;
+    addCriteria(critera: CriteriaFunc, criteriaValues: any[] ): RealmQuery;
     private getFilteredObjects();
     toString(): string;
     /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
 import { Results } from 'realm';
 export declare type ILogicOperator = 'AND' | 'OR';
 export declare type EqualValueType = string | number | boolean | Date;
-export declare type CompareValueType = number | Date
+export declare type CompareValueType = number | Date;
 export declare type CriteriaFunc = { (pladholders: string[]): string };
 export declare type CriteriaHof = { (): string };
 declare class RealmQuery {

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ export declare type ILogicOperator = 'AND' | 'OR';
 export declare type EqualValueType = string | number | boolean | Date;
 export declare type CompareValueType = number | Date;
 export declare type CriteriaFunc = { (pladholders: string[]): string };
-export declare type CriteriaHof = { (): string };
+export declare type CriteriaFuncWrapper = { (): string };
 declare class RealmQuery {
     private objects;
     protected criteria: any[];

--- a/src/realm-query.test.ts
+++ b/src/realm-query.test.ts
@@ -12,202 +12,256 @@ describe("RealmQuery", function () {
 
   it('should able to add new criteria', function () {
     expect(query['criteria'].length).to.equal(0);
-    query.addCriteria('id == 1');
+    query.addCriteria(() => 'id == 1')
     expect(query['criteria'].length).to.equal(1);
-  })
+  });
 
   describe("equalTo", function () {
     it('equalTo number', function () {
-      query.equalTo('id', 1001);
-      expect(query.toString()).to.equal('id == 1001');
+      const value = 1001;
+      query.equalTo('id', value);
+      expect(query.toString()).to.equal('id == $0');
+      expect(query._getValues()).to.deep.equal([value]);
     });
 
     it('equalTo string', function () {
-      query.equalTo('name', "username");
-      expect(query.toString()).to.equal('name == "username"');
+      const value = "username";
+      query.equalTo('name', value);
+      expect(query.toString()).to.equal('name == $0');
+      expect(query._getValues()).to.deep.equal([value]);
     });
 
     it('equalTo date', function () {
       const now = new Date();
       query.equalTo('createdAt', now);
-      expect(query.toString()).to.equal('createdAt == ' + now.toString());
+      expect(query.toString()).to.equal('createdAt == $0');
+      expect(query._getValues()).to.deep.equal([now]);
     });
 
     it('equalTo boolean', function () {
-      query.equalTo('isDeleted', true);
-      expect(query.toString()).to.equal('isDeleted == true');
+      const value = true;
+      query.equalTo('isDeleted', value);
+      expect(query.toString()).to.equal('isDeleted == $0');
+      expect(query._getValues()).to.deep.equal([value]);
     });
   });
 
   describe("notEqualTo", function () {
 
     it('notEqualTo number', function () {
-      query.notEqualTo('id', 1001);
-      expect(query.toString()).to.equal('id <> 1001');
+      const value = 1001;
+      query.notEqualTo('id', value);
+      expect(query.toString()).to.equal('id <> $0');
+      expect(query._getValues()).to.deep.equal([value]);
     });
 
     it('notEqualTo string', function () {
-      query.notEqualTo('name', "username");
-      expect(query.toString()).to.equal('name <> "username"');
+      const value = 'username';
+      query.notEqualTo('name', value);
+      expect(query.toString()).to.equal('name <> $0');
+      expect(query._getValues()).to.deep.equal([value]);
     });
 
     it('notEqualTo date', function () {
       const now = new Date();
       query.notEqualTo('createdAt', now);
-      expect(query.toString()).to.equal('createdAt <> ' + now.toString());
+      expect(query.toString()).to.equal('createdAt <> $0');
+      expect(query._getValues()).to.deep.equal([now]);
     });
 
     it('notEqualTo boolean', function () {
-      query.notEqualTo('isDeleted', true);
-      expect(query.toString()).to.equal('isDeleted <> true');
+      const value = true;
+      query.notEqualTo('isDeleted', value);
+      expect(query.toString()).to.equal('isDeleted <> $0');
+      expect(query._getValues()).to.deep.equal([value]);
     });
   });
 
   describe("beginsWith", function () {
+    const value = 'phu';
     it('beginsWith not casing', function () {
-      query.beginsWith('name', 'phu');
-      expect(query.toString()).to.equal('name BEGINSWITH "phu"');
+      query.beginsWith('name', value);
+      expect(query.toString()).to.equal('name BEGINSWITH $0');
+      expect(query._getValues()).to.deep.equal([value]);
     });
     it('beginsWith casing', function () {
-      query.beginsWith('name', 'phu', true);
-      expect(query.toString()).to.equal('name BEGINSWITH[c] "phu"');
+      query.beginsWith('name', value, true);
+      expect(query.toString()).to.equal('name BEGINSWITH[c] $0');
+      expect(query._getValues()).to.deep.equal([value]);
     });
   });
 
   describe("endsWith", function () {
+    const value = 'phu';
     it('endsWith not casing', function () {
-      query.endsWith('name', 'phu');
-      expect(query.toString()).to.equal('name ENDSWITH "phu"');
+      query.endsWith('name', value);
+      expect(query.toString()).to.equal('name ENDSWITH $0');
+      expect(query._getValues()).to.deep.equal([value]);
     });
     it('endsWith casing', function () {
-      query.endsWith('name', 'phu', true);
-      expect(query.toString()).to.equal('name ENDSWITH[c] "phu"');
+      query.endsWith('name', value, true);
+      expect(query.toString()).to.equal('name ENDSWITH[c] $0');
+      expect(query._getValues()).to.deep.equal([value]);
     });
   });
   describe("contains", function () {
+    const value = 'phu';
     it('contains not casing', function () {
-      query.contains('name', 'phu');
-      expect(query.toString()).to.equal('name CONTAINS "phu"');
+      query.contains('name', value);
+      expect(query.toString()).to.equal('name CONTAINS $0');
+      expect(query._getValues()).to.deep.equal([value]);
     });
     it('contains casing', function () {
       query.contains('name', 'phu', true);
-      expect(query.toString()).to.equal('name CONTAINS[c] "phu"');
+      expect(query.toString()).to.equal('name CONTAINS[c] $0');
+      expect(query._getValues()).to.deep.equal([value]);
     });
   });
 
   describe("between", function () {
     it('between number to number', function () {
-      query.between('age', 20, 30);
-      expect(query.toString()).to.equal('age >= 20 AND age <= 30');
+      const from = 20, to = 30;
+      query.between('age', from, to);
+      expect(query.toString()).to.equal('age >= $0 AND age <= $1');
+      expect(query._getValues()).to.deep.equal([from, to]);
     });
     it('between date to date', function () {
       const start = new Date();
       const end = new Date();
       query.between('createdAt', start, end);
-      expect(query.toString()).to.equal(`createdAt >= ${start} AND createdAt <= ${end}`);
+      expect(query.toString()).to.equal(`createdAt >= $0 AND createdAt <= $1`);
+      expect(query._getValues()).to.deep.equal([start, end]);
     });
   });
 
-  describe("Basic comparation", function () {
+  describe("Basic comparison", function () {
 
     it("greaterThan number", function () {
-      query.greaterThan('age', 20);
-      expect(query.toString()).to.equal('age > 20');
+      const value = 20;
+      query.greaterThan('age', value);
+      expect(query.toString()).to.equal('age > $0');
+      expect(query._getValues()).to.deep.equal([20]);
     });
 
     it("greaterThan a date", function () {
       const now = new Date();
       query.greaterThan('createdAt', now);
-      expect(query.toString()).to.equal('createdAt > ' + now.toString());
+      expect(query.toString()).to.equal('createdAt > $0');
+      expect(query._getValues()).to.deep.equal([now]);
     });
 
     it("greaterThanOrEqualTo number", function () {
-      query.greaterThanOrEqualTo('age', 20);
-      expect(query.toString()).to.equal('age >= 20');
+      const value = 20;
+      query.greaterThanOrEqualTo('age', value);
+      expect(query.toString()).to.equal('age >= $0');
+      expect(query._getValues()).to.deep.equal([value]);
     });
     it("greaterThanOrEqualTo a date", function () {
       const now = new Date();
       query.greaterThanOrEqualTo('createdAt', now);
-      expect(query.toString()).to.equal('createdAt >= ' + now.toString());
+      expect(query.toString()).to.equal('createdAt >= $0');
+      expect(query._getValues()).to.deep.equal([now]);
     });
 
     it("lessThan number", function () {
-      query.lessThan('age', 20);
-      expect(query.toString()).to.equal('age < 20');
+      const value = 20;
+      query.lessThan('age', value);
+      expect(query.toString()).to.equal('age < $0');
+      expect(query._getValues()).to.deep.equal([value]);
     });
     it("lessThan a date", function () {
       const now = new Date();
       query.lessThan('createdAt', now);
-      expect(query.toString()).to.equal('createdAt < ' + now.toString());
+      expect(query.toString()).to.equal('createdAt < $0');
+      expect(query._getValues()).to.deep.equal([now]);
     });
 
     it("lessThanOrEqualTo number", function () {
-      query.lessThanOrEqualTo('age', 20);
-      expect(query.toString()).to.equal('age <= 20');
+      const value = 20;
+      query.lessThanOrEqualTo('age', value);
+      expect(query.toString()).to.equal('age <= $0');
+      expect(query._getValues()).to.deep.equal([value]);
     });
     it("lessThanOrEqualTo a date", function () {
       const now = new Date();
       query.lessThanOrEqualTo('createdAt', now);
-      expect(query.toString()).to.equal('createdAt <= ' + now.toString());
+      expect(query.toString()).to.equal('createdAt <= $0');
+      expect(query._getValues()).to.deep.equal([now]);
     });
   });
   describe('In', function () {
     it('In array of number', function () {
-      query.in('id', [1, 2])
-      expect(query.toString()).to.equal('(id == 1 OR id == 2)');
-    })
+      const values = [1, 2];
+      query.in('id', values);
+      expect(query.toString()).to.equal('(id == $0 OR id == $1)');
+      expect(query._getValues()).to.deep.equal(values);
+    });
     it('In array of string', function () {
-      query.in('status', ["ACTIVE", "DEACTIVE"])
-      expect(query.toString()).to.equal('(status == "ACTIVE" OR status == "DEACTIVE")');
+      const values = ["ACTIVE", "DEACTIVE"];
+      query.in('status', values);
+      expect(query.toString()).to.equal('(status == $0 OR status == $1)');
+      expect(query._getValues()).to.deep.equal(values);
     });
     it('In array of mix values', function () {
-      query.in('id', [1001, "abcd"])
-      expect(query.toString()).to.equal('(id == 1001 OR id == "abcd")');
+      const values = [1001, "abcd"];
+      query.in('id', values);
+      expect(query.toString()).to.equal('(id == $0 OR id == $1)');
+      expect(query._getValues()).to.deep.equal(values);
     });
   });
 
   describe('Query with compound criterias', function () {
     it('complex query with or', function () {
+      const name = 'phu', age = 25, ids = [1001, 1002];
       query
-        .contains('name', 'phu', true)
+        .contains('name', name, true)
         .beginGroup()
-        .greaterThan('age', 25)
+        .greaterThan('age', age)
         .or()
-        .in('id', [1001, 1002])
+        .in('id', ids)
+      ;
+      let expectedFilters = 'name CONTAINS[c] $0 AND (age > $1 OR (id == $2 OR id == $3))';
+      expect(query.toString()).to.equal(expectedFilters);
+      expect(query._getValues()).to.deep.equal([name, age, ids[0], ids[1]]);
 
-      let expectedFilted = 'name CONTAINS[c] "phu" AND (age > 25 OR (id == 1001 OR id == 1002))'
-      expect(query.toString()).to.equal(expectedFilted);
     });
 
     it('complex query with and', function () {
+      const name = 'phu', age = 25, ids = [1001, 1002];
       query
-        .contains('name', 'phu', true)
+        .contains('name', name, true)
         .beginGroup()
-        .greaterThan('age', 25)
+        .greaterThan('age', age)
         .and()
-        .in('id', [1001, 1002])
-
-      let expectedFilted = 'name CONTAINS[c] "phu" AND (age > 25 AND (id == 1001 OR id == 1002))'
-      expect(query.toString()).to.equal(expectedFilted);
+        .in('id', ids)
+      ;
+      let expectedFilters = 'name CONTAINS[c] $0 AND (age > $1 AND (id == $2 OR id == $3))';
+      expect(query.toString()).to.equal(expectedFilters);
+      expect(query._getValues()).to.deep.equal([name, age, ids[0], ids[1]]);
     });
     it('complex query with not', function () {
+      const name = 'phu', age = 25, ids = [1001, 1002];
       query
         .not()
-        .contains('name', 'phu', true)
+        .contains('name', name, true)
         .beginGroup()
-        .greaterThan('age', 25)
+        .greaterThan('age', age)
         .and()
-        .in('id', [1001, 1002])
+        .in('id', ids)
+      ;
 
-      let expectedFilted = 'NOT(name CONTAINS[c] "phu" AND (age > 25 AND (id == 1001 OR id == 1002)))'
+      let expectedFilted = 'NOT(name CONTAINS[c] $0 AND (age > $1 AND (id == $2 OR id == $3)))';
       expect(query.toString()).to.equal(expectedFilted);
+      expect(query._getValues()).to.deep.equal([name, age, ids[0], ids[1]]);
     });
 
     it('combine complex query', function () {
-      query = RealmQuery.create().contains('name', 'phu', true);
-      let query2 = RealmQuery.create().in('id', [1001, 1002]);
+      const name = 'phu', ids = [1001, 1002];
+      query.contains('name', name, true);
+      let query2 = RealmQuery.create().in('id', ids);
       query.join(query2);
-      expect(query.toString()).to.equal('name CONTAINS[c] "phu" AND (id == 1001 OR id == 1002)');
+      expect(query.toString()).to.equal('name CONTAINS[c] $0 AND (id == $1 OR id == $2)');
+      expect(query._getValues()).to.deep.equal([name, ids[0], ids[1]]);
     });
   });
 
@@ -245,10 +299,10 @@ describe('Get objects with RealmQuery', function () {
   });
 
   it('Find all with filtered', function () {
-    let results = RealmQuery
+    let query = RealmQuery
       .where(realm.objects('Person'))
-      .greaterThan('age', 30)
-      .findAll()
+      .greaterThan('age', 30);
+    const results = query.findAll();
     expect(results.length).to.equal(2);
   });
 
@@ -263,7 +317,7 @@ describe('Get objects with RealmQuery', function () {
     let result = RealmQuery
       .where(realm.objects('Person'))
       .greaterThan('age', 30)
-      .findFirst()
+      .findFirst();
     let expected = realm.objects('Person').filtered('age > 30')[0];
     expect(JSON.stringify(result)).to.equal(JSON.stringify(expected));
   });

--- a/src/realm-query.test.ts
+++ b/src/realm-query.test.ts
@@ -322,6 +322,14 @@ describe('Get objects with RealmQuery', function () {
     expect(JSON.stringify(result)).to.equal(JSON.stringify(expected));
   });
 
+  it('Find all with less than date filter', function () {
+      let query = RealmQuery
+          .where(realm.objects('Person'))
+          .lessThan('createdAt', new Date("2010-01-01 00:00:00"));
+      const results = query.findAll();
+      expect(results.length).to.equal(3);
+  });
+
   it('Count', function () {
     let total = RealmQuery
       .where(realm.objects('Person'))

--- a/src/realm-query.ts
+++ b/src/realm-query.ts
@@ -28,6 +28,8 @@ class RealmQuery {
   }
 
   addCriteria(criteriaCallback: CriteriaFunc, criteriaValues: any[] = []): RealmQuery {
+    // NOTE: This high order function has the side effect of manipulating the 'values' array.
+    // NOTE: Which is necessary for generating the proper binding palcholders
     let criteria: CriteriaHof = function () {
       const placeholderCallback = function (value) {
           const index = this.values.length;
@@ -59,6 +61,8 @@ class RealmQuery {
     return results;
   }
   public toString(): string {
+    // Values for bindings must be cleared out since we're calling toString again
+    this.values = [];
     let criteriaStr = [];
     let hasNotOperator = false;
     for (let i in this.criteria) {

--- a/src/realm-query.ts
+++ b/src/realm-query.ts
@@ -39,7 +39,7 @@ class RealmQuery {
           this.values.push(value);
           return `$${index}`;
       };
-      const placeholders: string[] = criteriaValues.map(placeholderCallback.bind(this));
+      const placeholders: string[] = criteriaValues.map(placeholderCallback.bind(this)) as string[];
       return criteriaCallback(placeholders);
     };
     if (this.inGroup) {


### PR DESCRIPTION
# Goals for PR
- Fix filtering by Date Properties which can only be done through placeholder bindings(i.e. date == $0)
- Some testing for retrieving Objects based on a filter applied to a Date Property
- Remove the need to add any delimiter characters for binding a filter's values in template string( i.e name == 'bob' -> name == $0 )

# Reasoning for complex or extensive changes
- Wrapper Functions for generating Query String Parts in toString() method
  - Delaying the determination of Query String Parts is necessary for generating the proper binding placeholders(i.e. date == $0)
- RealmQuery.values attribute
  - We needed some place to store the values from all the criteria/filters that were being declared for a RealmQuery
  - It is a necessary side effect in order to call Results.filtered('< your query>', bindingValues) with the bindingValues in the correct order
  - It is re-populate on every toString() call. So it does not contain duplicates from previous calls
- Binding Placeholders
  - No need to specify string values with single quotes(i.e. name == 'bob' -> name = $0)
  - Can now specify criteria for Date Properties
- Tests
  - Instead of comparing against already bound query strings(i.e. age = 25) we are comparing against pre bound query string parts(i.e. age = $0)
  - In addition to make sure that all the binding values are available for when getFilteredObjects is called, we check to make sure 'values' contains what we would expect for the correct query

# Improvements
- interface enhancements for Realm Query
  - Would be better to have a method called buildQuery() : { query: str, bindingValues: any[] } instead of toString() that returns the query string and binding values.
  - OR move functionality from toString method to a method like toStringRaw. Then switch toString to interpolating the values in the template literals for the query string(i.e. age > $0 -> age > 25 )

# Breaking Changes
- Dependency upon return value of toString() for calling Results.filtered(queryStr)
  - Upgrade path
    - Before
    ```
    ... statements building up query
    var queryString = realmQuery.toString();
    personResults.filtered(queryString);
    ```
    - After
    ```
       var queryString = realmQuery.toString();
       var values = realmQuery._getValues();
       personResults.filtered(queryString, values);
       OR...
       // Only rely on methods that perform Results.filtered() behind the scenes
       ....
       realmQuery<type>.findAll();
    ```
  - Or we could make toString() operate the same as before but with the limitations of Date Property filtering not working. And then have a separate toStringBindings() or something that is used by the fetching methods of RealmQuery.